### PR TITLE
PMM-13826 handled role check to show editor users failed advisors number

### DIFF
--- a/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
+++ b/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
@@ -230,7 +230,6 @@ describe('Failed::', () => {
     config.bootData.user.isGrafanaAdmin = false;
     config.bootData.user.orgRole = OrgRole.Viewer;
 
-    expect(spyGetAllFailedChecks).not.toHaveBeenCalled();
     render(
       <Provider
         store={configureStore({
@@ -245,5 +244,7 @@ describe('Failed::', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('unauthorized')).toBeInTheDocument());
+
+    expect(spyGetAllFailedChecks).not.toHaveBeenCalled();
   });
 });

--- a/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
+++ b/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
@@ -17,7 +17,7 @@ describe('Failed::', () => {
     config.bootData.user.orgRole = OrgRole.Admin;
   });
 
-  it('should render a sum of total failed checks with severity details', async () => {
+  it('should render a sum of total failed checks with severity details for admin user', async () => {
     jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
       {
         serviceName: '',
@@ -70,7 +70,62 @@ describe('Failed::', () => {
     await waitFor(() => expect(screen.getByTestId('db-check-panel-notice').textContent).toEqual('0'));
   });
 
-  it('should render 0 when the sum of all checks is zero', async () => {
+  it('should render a sum of total failed checks with severity details for editor user', async () => {
+    config.bootData.user.isGrafanaAdmin = false;
+    config.bootData.user.orgRole = OrgRole.Editor;
+    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+      {
+        serviceName: '',
+        serviceId: '',
+        counts: {
+          emergency: 0,
+          critical: 1,
+          alert: 0,
+          error: 0,
+          warning: 2,
+          notice: 0,
+          info: 0,
+          debug: 0,
+        },
+      },
+      {
+        serviceName: '',
+        serviceId: '',
+        counts: {
+          emergency: 0,
+          critical: 2,
+          alert: 0,
+          error: 0,
+          warning: 0,
+          notice: 0,
+          info: 0,
+          debug: 0,
+        },
+      },
+    ]);
+
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: false },
+            settings: { loading: false, result: { advisorEnabled: true, isConnectedToPortal: false } },
+          },
+        } as StoreState)}
+      >
+        <Failed />
+      </Provider>
+    );
+
+    await waitFor(() => expect(CheckService.getAllFailedChecks).toHaveBeenCalled());
+
+    await waitFor(() => expect(screen.getByTestId('db-check-panel-critical').textContent).toEqual('3'));
+    await waitFor(() => expect(screen.getByTestId('db-check-panel-error').textContent).toEqual('0'));
+    await waitFor(() => expect(screen.getByTestId('db-check-panel-warning').textContent).toEqual('2'));
+    await waitFor(() => expect(screen.getByTestId('db-check-panel-notice').textContent).toEqual('0'));
+  });
+
+  it('should render 0 when the sum of all checks is zero for admin user', async () => {
     jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
       {
         serviceName: '',
@@ -118,7 +173,59 @@ describe('Failed::', () => {
     await waitFor(() => expect(screen.getByTestId('db-check-panel-zero-checks')).toBeInTheDocument());
   });
 
-  it('should render a message when the user only has reader access', async () => {
+  it('should render 0 when the sum of all checks is zero for editor user', async () => {
+    config.bootData.user.isGrafanaAdmin = false;
+    config.bootData.user.orgRole = OrgRole.Editor;
+    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+      {
+        serviceName: '',
+        serviceId: '',
+        counts: {
+          emergency: 0,
+          critical: 0,
+          alert: 0,
+          error: 0,
+          warning: 0,
+          notice: 0,
+          info: 0,
+          debug: 0,
+        },
+      },
+      {
+        serviceName: '',
+        serviceId: '',
+        counts: {
+          emergency: 0,
+          critical: 0,
+          alert: 0,
+          error: 0,
+          warning: 0,
+          notice: 0,
+          info: 0,
+          debug: 0,
+        },
+      },
+    ]);
+
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: false },
+            settings: { loading: false, result: { advisorEnabled: true, isConnectedToPortal: false } },
+          },
+        } as StoreState)}
+      >
+        <Failed />
+      </Provider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('db-check-panel-zero-checks')).toBeInTheDocument());
+  });
+
+  it('should render a message and no failed checks for viewer user', async () => {
+    config.bootData.user.isGrafanaAdmin = false;
+    config.bootData.user.orgRole = OrgRole.Viewer;
     render(
       <Provider
         store={configureStore({

--- a/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
+++ b/public/app/plugins/panel/pmm-check/components/Failed/Failed.test.tsx
@@ -11,14 +11,17 @@ import { Failed } from './Failed';
 
 jest.mock('app/percona/check/Check.service');
 
+const spyGetAllFailedChecks = jest.spyOn(CheckService, 'getAllFailedChecks');
+
 describe('Failed::', () => {
   beforeEach(() => {
     config.bootData.user.isGrafanaAdmin = true;
     config.bootData.user.orgRole = OrgRole.Admin;
+    spyGetAllFailedChecks.mockClear();
   });
 
   it('should render a sum of total failed checks with severity details for admin user', async () => {
-    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+    spyGetAllFailedChecks.mockImplementationOnce(async () => [
       {
         serviceName: '',
         serviceId: '',
@@ -73,7 +76,7 @@ describe('Failed::', () => {
   it('should render a sum of total failed checks with severity details for editor user', async () => {
     config.bootData.user.isGrafanaAdmin = false;
     config.bootData.user.orgRole = OrgRole.Editor;
-    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+    spyGetAllFailedChecks.mockImplementationOnce(async () => [
       {
         serviceName: '',
         serviceId: '',
@@ -126,7 +129,7 @@ describe('Failed::', () => {
   });
 
   it('should render 0 when the sum of all checks is zero for admin user', async () => {
-    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+    spyGetAllFailedChecks.mockImplementationOnce(async () => [
       {
         serviceName: '',
         serviceId: '',
@@ -176,7 +179,7 @@ describe('Failed::', () => {
   it('should render 0 when the sum of all checks is zero for editor user', async () => {
     config.bootData.user.isGrafanaAdmin = false;
     config.bootData.user.orgRole = OrgRole.Editor;
-    jest.spyOn(CheckService, 'getAllFailedChecks').mockImplementationOnce(async () => [
+    spyGetAllFailedChecks.mockImplementationOnce(async () => [
       {
         serviceName: '',
         serviceId: '',
@@ -223,9 +226,11 @@ describe('Failed::', () => {
     await waitFor(() => expect(screen.getByTestId('db-check-panel-zero-checks')).toBeInTheDocument());
   });
 
-  it('should render a message and no failed checks for viewer user', async () => {
+  it('should render unauthorised message and no failed checks for viewer user', async () => {
     config.bootData.user.isGrafanaAdmin = false;
     config.bootData.user.orgRole = OrgRole.Viewer;
+
+    expect(spyGetAllFailedChecks).not.toHaveBeenCalled();
     render(
       <Provider
         store={configureStore({

--- a/public/app/plugins/panel/pmm-check/components/Failed/Failed.tsx
+++ b/public/app/plugins/panel/pmm-check/components/Failed/Failed.tsx
@@ -7,7 +7,7 @@ import { CheckService } from 'app/percona/check/Check.service';
 import { FailedCheckSummary } from 'app/percona/check/types';
 import { getPerconaSettings, getPerconaUser } from 'app/percona/shared/core/selectors';
 import { logger } from 'app/percona/shared/helpers/logger';
-import { isPmmAdmin } from 'app/percona/shared/helpers/permissions';
+import { isPmmAdmin, isEditor } from 'app/percona/shared/helpers/permissions';
 import { useSelector } from 'app/types';
 
 import { PMM_DATABASE_CHECKS_PANEL_URL, PMM_SETTINGS_URL } from '../../CheckPanel.constants';
@@ -37,7 +37,7 @@ export const Failed: FC = () => {
   }, []);
 
   useEffect(() => {
-    if (isPmmAdmin(config.bootData.user)) {
+    if (isPmmAdmin(config.bootData.user) || isEditor(config.bootData.user)) {
       fetchAlerts();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -47,7 +47,7 @@ export const Failed: FC = () => {
     return <Spinner />;
   }
 
-  if (!isAuthorized) {
+  if (!isAuthorized && !isEditor(config.bootData.user)) {
     return (
       <div className={styles.Empty} data-testid="unauthorized">
         {Messages.insufficientPermissions}


### PR DESCRIPTION
[PMM-13826](https://perconadev.atlassian.net/browse/PMM-13826)
https://github.com/Percona-Lab/pmm-submodules/pull/3867



[PMM-13826]: https://perconadev.atlassian.net/browse/PMM-13826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ