### PR TITLE
PMM-13781 v3 missing MyRocks but still shows TokuDB

### DIFF
--- a/public/app/percona/shared/components/PerconaBootstrapper/PerconaNavigation/PerconaNavigation.constants.ts
+++ b/public/app/percona/shared/components/PerconaBootstrapper/PerconaNavigation/PerconaNavigation.constants.ts
@@ -441,10 +441,10 @@ export const PMM_NAV_MYSQL: NavModelItem = {
       url: `${config.appSubUrl}/d/mysql-table/mysql-table-details`,
     },
     {
-      id: 'mysql-tokudb-details',
-      text: 'TokuDB details',
+      id: 'mysql-myrocks-details',
+      text: 'MyRocks details',
       icon: 'sitemap',
-      url: `${config.appSubUrl}/d/mysql-tokudb/mysql-tokudb-details`,
+      url: `${config.appSubUrl}/d/mysql-myrocks/mysql-myrocks-details`,
     },
   ],
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
TokuDB has been dead a long time. MyRocks is current, and customers are using it actively in production. PMMv3 navigation menu removed MyRocks, but kept TokuDB.

Recommend removing/hiding TokuDB from navigation menu, and replacing with MyRocks.

**Which issue(s) this PR fixes**:
https://perconadev.atlassian.net/browse/PMM-13781

Was:
<img width="1706" height="851" alt="TokuDB" src="https://github.com/user-attachments/assets/9d65b94d-ba1f-412f-ac28-23fccf264c12" />
Resolved issue:
<img width="1483" height="777" alt="Myrocks" src="https://github.com/user-attachments/assets/0d0d99fc-d6c6-4bf0-a8e1-d35058d473bd" />


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

